### PR TITLE
update support mail in sidebar

### DIFF
--- a/src/components/admin/left-side-bar/SidebarHelp.js
+++ b/src/components/admin/left-side-bar/SidebarHelp.js
@@ -30,7 +30,7 @@ export function SidebarHelp(props) {
             Need Help?
           </Text>
           <Text fontSize="16px" >
-            Get in touch with our support team at support@riftly.xyz
+            Get in touch with our support team at support@qu3st.io
           </Text>
           <Button variant='ghost'>Get in touch</Button>
         </Flex>


### PR DESCRIPTION
Monday URL: https://qu3st.monday.com/boards/4464034936/pulses/4465360548

<img width="453" alt="Screenshot 2023-05-20 at 14 12 19" src="https://github.com/quan612/riftly-admin/assets/9070957/234c75c5-99f6-4d47-b5d0-15fa92e8d212">

Change support@riftly.xyz to a support@qu3st.io email.